### PR TITLE
Fixed a HLSL code generation issue with GPU emitter

### DIFF
--- a/Plugins/FX/HoudiniNiagara/.gitignore
+++ b/Plugins/FX/HoudiniNiagara/.gitignore
@@ -1,0 +1,2 @@
+Binaries/
+Intermediate/

--- a/Plugins/FX/HoudiniNiagara/Source/HoudiniNiagara/Private/NiagaraDataInterfaceHoudini.cpp
+++ b/Plugins/FX/HoudiniNiagara/Source/HoudiniNiagara/Private/NiagaraDataInterfaceHoudini.cpp
@@ -3296,7 +3296,7 @@ bool UNiagaraDataInterfaceHoudini::GetFunctionHLSL(const FNiagaraDataInterfaceGP
 			AttributeTypeName = "float";
 			AdditionalFunctionArguments = "";
 			VectorExFunctionDefaults = "";
-			ReadFromBufferSnippet = ReadFloatInBuffer(TEXT("In_SampleIndex"), TEXT("AttributeIndex"), TEXT("Out_Value"));
+			ReadFromBufferSnippet = ReadFloatInBuffer(TEXT("Out_Value"), TEXT("In_SampleIndex"), TEXT("AttributeIndex"));
 		}
 		else if (FunctionInfo.DefinitionName == GetVectorValueByStringName)
 		{
@@ -3306,14 +3306,14 @@ bool UNiagaraDataInterfaceHoudini::GetFunctionHLSL(const FNiagaraDataInterfaceGP
 				"	bool In_DoSwap = true;\n"
 				"	bool In_DoScale = true;\n"
 			);
-			ReadFromBufferSnippet = ReadVectorInBuffer(TEXT("In_SampleIndex"), TEXT("AttributeIndex"), TEXT("Out_Value"));
+			ReadFromBufferSnippet = ReadVectorInBuffer(TEXT("Out_Value"), TEXT("In_SampleIndex"), TEXT("AttributeIndex"));
 		}
 		else if (FunctionInfo.DefinitionName == GetVectorValueExByStringName)
 		{
 			AttributeTypeName = "float3";
 			AdditionalFunctionArguments = TEXT("bool In_DoSwap, bool In_DoScale, ");
 			VectorExFunctionDefaults = "";
-			ReadFromBufferSnippet = ReadVectorInBuffer(TEXT("In_SampleIndex"), TEXT("AttributeIndex"), TEXT("Out_Value"));
+			ReadFromBufferSnippet = ReadVectorInBuffer(TEXT("Out_Value"), TEXT("In_SampleIndex"), TEXT("AttributeIndex"));
 		}
 		else if (FunctionInfo.DefinitionName == GetVector4ValueByStringName)
 		{
@@ -3322,14 +3322,14 @@ bool UNiagaraDataInterfaceHoudini::GetFunctionHLSL(const FNiagaraDataInterfaceGP
 			VectorExFunctionDefaults = TEXT(
 				"	bool In_DoHoudiniToUnrealConversion = false;\n"
 			);
-			ReadFromBufferSnippet = ReadVector4InBuffer(TEXT("In_SampleIndex"), TEXT("AttributeIndex"), TEXT("Out_Value"));
+			ReadFromBufferSnippet = ReadVector4InBuffer(TEXT("Out_Value"), TEXT("In_SampleIndex"), TEXT("AttributeIndex"));
 		}
 		else if (FunctionInfo.DefinitionName == GetQuatValueByStringName)
 		{
 			AttributeTypeName = "float4";
 			AdditionalFunctionArguments = TEXT("bool In_DoHoudiniToUnrealConversion, ");
 			VectorExFunctionDefaults = "";
-			ReadFromBufferSnippet = ReadVector4InBuffer(TEXT("In_SampleIndex"), TEXT("AttributeIndex"), TEXT("Out_Value"));
+			ReadFromBufferSnippet = ReadVector4InBuffer(TEXT("Out_Value"), TEXT("In_SampleIndex"), TEXT("AttributeIndex"));
 		}
 		else
 		{


### PR DESCRIPTION
There were instances where ReadFloatInBuffer, ReadVectorInBuffer and
ReadVector4InBuffer were called with the function parameters in an
incorrect order that lead to invalid and incorrect array referencing
in the generated HLSL code.

Added a basic .gitignore file to ignore the Binaries and Intermediate
directories.