### PR TITLE
Fix incorrect minor engine version requirement.

### DIFF
--- a/HoudiniNiagara.uplugin
+++ b/HoudiniNiagara.uplugin
@@ -2,7 +2,7 @@
 	"FileVersion": 3,
 	"Version": 2,
 	"VersionName": "2.3.0",
-	"EngineVersion" : "5.00.0",
+	"EngineVersion" : "5.0.0",
 	"FriendlyName": "Houdini Niagara",
 	"Description": "Import Houdini point cloud data into UE5 to drive Niagara particle systems.",
 	"Category": "FX",


### PR DESCRIPTION
The current engine version requirement made Unreal question which engine it was built for.

![image](https://user-images.githubusercontent.com/99779/178379368-39f63163-2959-4772-8a14-d38d2fb5e3eb.png)
