### PR TITLE
Fix missing WITH_EDITORONLY_DATA for Standalone builds

### DIFF
--- a/Source/HoudiniNiagara/Classes/NiagaraDataInterfaceHoudini.h
+++ b/Source/HoudiniNiagara/Classes/NiagaraDataInterfaceHoudini.h
@@ -287,11 +287,12 @@ public:
 	
 	//----------------------------------------------------------------------------
 	// GPU / HLSL Functions
+#if WITH_EDITORONLY_DATA
 	virtual bool GetFunctionHLSL(const FNiagaraDataInterfaceGPUParamInfo& ParamInfo, const FNiagaraDataInterfaceGeneratedFunction& FunctionInfo, int FunctionInstanceIndex, FString& OutHLSL) override;
 	virtual bool AppendCompileHash(FNiagaraCompileHashVisitor* InVisitor) const override;
 	virtual void GetParameterDefinitionHLSL(const FNiagaraDataInterfaceGPUParamInfo& ParamInfo, FString& OutHLSL) override;
 	virtual void GetCommonHLSL(FString& OutHLSL) override;
-
+#endif
 
 	//virtual bool UseLegacyShaderBindings() const override { return false; }
 	virtual void BuildShaderParameters(FNiagaraShaderParametersBuilder& ShaderParametersBuilder) const override;


### PR DESCRIPTION
The `#if WITH_EDITORONLY_DATA` statements was removed in commit fbd2b3078cfd2ff8f5348d7f801cca71166dbde3. I simply re-added them (and moved `UNiagaraDataInterfaceHoudini::GetCommonHLSL()` to be within the conditional), to make Standalone able to compile without errors.